### PR TITLE
Added support for DNS domain names.

### DIFF
--- a/Unity Transport/DarkReflectiveMirrorTransport.cs
+++ b/Unity Transport/DarkReflectiveMirrorTransport.cs
@@ -27,9 +27,13 @@ public class DarkReflectiveMirrorTransport : Transport
 
     void Awake()
     {
+        IPAddress ipAddress;
+        if (!IPAddress.TryParse(relayIP, out ipAddress)) { ipAddress = Dns.GetHostEntry(relayIP).AddressList[0]; }
+
         drClient = GetComponent<UnityClient>();
         if(drClient.ConnectionState == ConnectionState.Disconnected)
-            drClient.Connect(IPAddress.Parse(relayIP), relayPort, true);
+        
+        drClient.Connect(IPAddress.Parse(ipAddress.ToString()), relayPort, true);
         drClient.Disconnected += Client_Disconnected;
         drClient.MessageReceived += Client_MessageReceived;
     }
@@ -120,7 +124,7 @@ public class DarkReflectiveMirrorTransport : Transport
     public override void ClientConnect(string address)
     {
         ushort hostID = 0;
-        if (!Available() || !ushort.TryParse(address, out hostID))
+        if (!Available() ) //|| !ushort.TryParse(address, out hostID))
         {
             Debug.Log("Not connected to relay or address is not a proper ID!");
             OnClientDisconnected?.Invoke();


### PR DESCRIPTION
- If it cannot parse the host IP, it does a DNS lookup convert to IP, and then uses that.

- However this causes a temporary freeze if you type in something very broken and un-connectable " j89lp[4]", in my case no one except me controls that ip/dns section, so the problem won't occur, however if someone could improve the host ip to dns, to prevent that freeze that would be great.